### PR TITLE
do not use net namespace, which will try to create multiple proc files

### DIFF
--- a/src/hostset.c
+++ b/src/hostset.c
@@ -47,6 +47,8 @@ int hs_init(struct host_set *hs, const char *name)
     hs->hosts = RB_ROOT;
     hs->filesize = 0;
     
+    pr_info("Creating procfs file for host set /proc/net/xt_tls/hostset/%s\n", name);
+
     hs->proc_file = proc_create_data(name, 0644, proc_fs_hostset_dir, 
 	    &proc_fops, hs);
     if (! hs->proc_file) {


### PR DESCRIPTION
the old code doesn't work if the linux host has has multiple net namespaces, for example, more net namespaces will be created if docker containers are used. namespaces can be listed via `sudo lsns | grep net`

if there are many namespaces, the same proc folder will be created multiple times, and later ones will be invisible from /proc/net/. so all the hostsets will be created under the last one (which is invisible). 

to meet our need, it's not necessary to hook on net namespace, we just use a single procfs for all namespaces.

**GGWalla**

```
pi@firewalla:~/xt_tls/src (GGwalla) $ sudo lsns | grep net
4026531993 net       313     1 root  /sbin/init maybe-ubiquity
4026532328 net        16 22551 root  s6-svscan -t0 /var/run/s6/services
4026532589 net         1 22571 65532 cloudflared --no-autoupdate proxy-dns
```

**MyGoldWalla**
```
pi@firewalla:~ (MyGoldWalla) $ sudo lsns | grep net
4026531993 net       334     1 root  /sbin/init maybe-ubiquity
4026532325 net         3  8127 root  bash /usr/local/bin/docker-entrypoint.sh unifi
```

**FireTest**
```
pi@firewalla:~ (Firetest) $ sudo lsns | grep net
4026531993 net       284     1 root  /sbin/init maybe-ubiquity
```